### PR TITLE
New Pip version

### DIFF
--- a/languages/pip/Dockerfile
+++ b/languages/pip/Dockerfile
@@ -1,6 +1,6 @@
 FROM attemptthisonline/python
 
-ARG PIP_VERSION=v1.0.1
+ARG PIP_VERSION=v1.0.2
 
 RUN curl -L https://github.com/dloscutoff/pip/archive/refs/tags/$PIP_VERSION.tar.gz | \
     tar -xz && \


### PR DESCRIPTION
v1.0.2 fixes a bug that made the `UQ` operator unusable.