### PR TITLE
Fix issue where exit code is 137 with 05AB1E

### DIFF
--- a/languages/05ab1e/Dockerfile
+++ b/languages/05ab1e/Dockerfile
@@ -12,4 +12,4 @@ RUN curl -L https://github.com/Adriandmen/05AB1E/archive/$OSABIE_REV.zip -o 05ab
     PATH=/opt/elixir/bin:$PATH mix deps.get && \
     (yes | PATH=/opt/elixir/bin:$PATH MIX_ENV=prod mix escript.build) && \
     mv osabie .. && \
-    rm /tmp/05ab1e.zip
+    rm /tmp/05ab1e.zip || true


### PR DESCRIPTION
[As you can see here](https://github.com/attempt-this-online/languages/runs/6483907063?check_suite_focus=true), it failed to push to Docker because of the exit code being 137. It does this on my computer too, but I thought it was normal because it still runs fine. This adds a workaround by just doing `|| true`. This fixes it on my computer, hopefully it fixes it on github's actions too