### PR TITLE
Bump Vyxal to 2.18.0

### DIFF
--- a/languages/vyxal/Dockerfile
+++ b/languages/vyxal/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
-ARG VYXAL_REV=v2.17.1
+ARG VYXAL_REV=v2.18.0
 
 RUN pip install vyxal==$VYXAL_REV


### PR DESCRIPTION
Because it's a increase in the minor version. If it was 2.17.2 I wouldn't have bothered.