### PR TITLE
Bump Chapel version to 1.29.0 (released Dec 15)

### DIFF
--- a/languages/chapel/Dockerfile
+++ b/languages/chapel/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/clang
 
-ARG CHAPEL_VERSION=1.28.0
+ARG CHAPEL_VERSION=1.29.0
 
 ENV CHPL_HOME=/opt/chapel CHPL_LLVM=system
 RUN pacman -Syu --noconfirm python cmake && \


### PR DESCRIPTION
This bumps the Chapel version to 1.29.0 to bring it up-to-date with
the latest release, made on December 15.