### PR TITLE
Bump Vyxal to 2.18.5

### DIFF
--- a/languages/vyxal/Dockerfile
+++ b/languages/vyxal/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
-ARG VYXAL_REV=v2.18.0
+ARG VYXAL_REV=v2.18.5
 
 RUN pip install vyxal==$VYXAL_REV


### PR DESCRIPTION
Quite a bit has changed since 2.18.0, so a version update shouldn't be too useless.