### PR TITLE
Add Nekomata

### DIFF
--- a/languages/hops/Dockerfile
+++ b/languages/hops/Dockerfile
@@ -10,6 +10,6 @@ RUN curl -L https://github.com/akc/hops/archive/$HOPS_REV.tar.gz | \
     cd hops-$HOPS_REV && \
     patch < /tmp/without_doc.patch && \
     rm /tmp/without_doc.patch && \
-    cabal --store-dir /opt/cabal install --package-env /opt/ghc_env --installdir /usr/local/bin --allow-newer && \
+    cabal --store-dir /opt/cabal install --package-env /opt/ghc_env --install-method=copy --installdir /usr/local/bin --allow-newer && \
     cd / && \
     rm -rf /tmp/hops-$HOPS_REV

--- a/languages/nekomata/Dockerfile
+++ b/languages/nekomata/Dockerfile
@@ -1,0 +1,11 @@
+#syntax=docker/dockerfile-upstream:1.4.0-rc1
+FROM attemptthisonline/haskell
+
+ARG NEKOMATA_VERSION=0.2.0.0
+
+RUN curl -L https://github.com/AlephAlpha/Nekomata/archive/refs/tags/v$NEKOMATA_VERSION.tar.gz | \
+    tar -xz && \
+    cd Nekomata-$NEKOMATA_VERSION && \
+    cabal --store-dir /opt/cabal install --package-env /opt/ghc_env --install-method=copy --installdir /usr/local/bin && \
+    cd / && \
+    rm -rf /tmp/Nekomata-$NEKOMATA_VERSION


### PR DESCRIPTION
Add [Nekomata](https://github.com/AlephAlpha/Nekomata).

Nekomata is built with cabal like Hops. I added the flag `--install-method=copy` to Hops's cabal build command so that the bin file is not a symlink. I'm not sure if this would fix Hops's problem.