### PR TITLE
Bump Thunno 2 to 2.1.9

### DIFF
--- a/languages/thunno2/Dockerfile
+++ b/languages/thunno2/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
-ARG THUNNO_REV=2.0.6
+ARG THUNNO_REV=2.1.9
 
 RUN pip install thunno2==$THUNNO_REV


### PR DESCRIPTION
It's been (almost) a month since my last PR, and a lot has changed in Thunno 2. I didn't want to miss the deployment and have Thunno 2 on a previous version when it got deployed, though.

I'll be back in approximately a month for another bump.