### PR TITLE
Bump Factor to latest dev release

### DIFF
--- a/languages/factor/Dockerfile
+++ b/languages/factor/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
-ARG FACTOR_VERSION=2022-02-16-17-52
+ARG FACTOR_VERSION=2023-06-03-00-14
 
 RUN curl -L https://downloads.factorcode.org/linux-x86-64/factor-linux-x86-64-$FACTOR_VERSION.tar.gz | \
     tar -xz && \


### PR DESCRIPTION
I literally just changed the version number in Dockerfile. The image builds and factor inside seems intact, not sure how extensively I should test this.