### PR TITLE
Add PowerShell

### DIFF
--- a/languages/pwsh/Dockerfile
+++ b/languages/pwsh/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
-ARG PWSH_VERSION=7.2.11
+ARG PWSH_VERSION=7.3.4
 
 RUN mkdir -p /opt/microsoft/powershell/7 && \
     curl -L https://github.com/PowerShell/PowerShell/releases/download/v$PWSH_VERSION/powershell-$PWSH_VERSION-linux-x64.tar.gz | \

--- a/languages/pwsh/Dockerfile
+++ b/languages/pwsh/Dockerfile
@@ -1,0 +1,10 @@
+#syntax=docker/dockerfile-upstream:1.4.0-rc1
+FROM attemptthisonline/base
+
+ARG PWSH_VERSION=7.2.11
+
+RUN mkdir -p /opt/microsoft/powershell/7 && \
+    curl -L https://github.com/PowerShell/PowerShell/releases/download/v$PWSH_VERSION/powershell-$PWSH_VERSION-linux-x64.tar.gz | \
+    tar -zx -C /opt/microsoft/powershell/7 && \
+    chmod +x /opt/microsoft/powershell/7/pwsh && \
+    ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh


### PR DESCRIPTION
Adds the current latest version of PowerShell, [v7.3.4](https://github.com/PowerShell/PowerShell/releases/tag/v7.3.4)

I tested that I was able to run PowerShell commands using the image build by this Dockerfile