### PR TITLE
Bump Chapel version to 1.31

### DIFF
--- a/languages/chapel/Dockerfile
+++ b/languages/chapel/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
-ARG CHAPEL_VERSION=1.30.0
+ARG CHAPEL_VERSION=1.31.0
 
 ENV CHPL_HOME=/opt/chapel CHPL_LLVM=none
 RUN pacman -Syu --noconfirm python cmake && \


### PR DESCRIPTION
This bumps the copy of Chapel used with ATO to version 1.31, which was released on June 22, 2023.