### PR TITLE
Factor: update to the official 0.99 release

### DIFF
--- a/languages/factor/Dockerfile
+++ b/languages/factor/Dockerfile
@@ -1,8 +1,16 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
-ARG FACTOR_VERSION=2023-07-30-13-46
+# Nightly:
+# ARG FACTOR_VERSION=2023-07-30-13-46
+#
+# RUN curl -L https://downloads.factorcode.org/linux-x86-64/factor-linux-x86-64-$FACTOR_VERSION.tar.gz | \
+#     tar -xz && \
+#     mv factor /opt/
 
-RUN curl -L https://downloads.factorcode.org/linux-x86-64/factor-linux-x86-64-$FACTOR_VERSION.tar.gz | \
+# Release:
+ARG FACTOR_VERSION=0.99
+
+RUN curl -L https://downloads.factorcode.org/releases/$FACTOR_VERSION/factor-linux-x86-64-0.99.tar.gz | \
     tar -xz && \
     mv factor /opt/


### PR DESCRIPTION
Due to some mess regarding Factor nightly builds folder I am switching to the official release link. This should probably be switched back to nightly when significant changes in development are made, as I don't think anyone actually uses the official release instead of whatever the state of the development repo is. 0.99 came out literal days ago though so it is very much up to date at this point.