### PR TITLE
Bump Chapel version to 1.33 (released yesterday)

### DIFF
--- a/languages/chapel/Dockerfile
+++ b/languages/chapel/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
-ARG CHAPEL_VERSION=1.32.0
+ARG CHAPEL_VERSION=1.33.0
 
 ENV CHPL_HOME=/opt/chapel CHPL_LLVM=none
 RUN pacman -Syu --noconfirm python cmake && \


### PR DESCRIPTION
This update designed to keep ATO up-to-date with the latest release of Chapel.