### PR TITLE
Fix CI when no images change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             exit_status=$?
           }
 
-          set -o nullglob
+          shopt -s nullglob
           for file in output/*.log; do
             name=${file#output/}
             name=${name%.log}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
             exit_status=$?
           }
 
+          set -o nullglob
           for file in output/*.log; do
             name=${file#output/}
             name=${name%.log}


### PR DESCRIPTION
By default, a glob in bash which doesn't match any files will be left verbatim. This was causing failures because it was trying to find the file literally called `output/*.log` (which of course doesn't exist) The nullglob option changes it so the argument is just removed (so the loop simply doesn't run over any files)