### PR TITLE
Reset podman before each CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,8 @@ init:
   extends: .base
   stage: init
   script:
+    # this ensures no stale cache is used - and we have enough disk space for a full build
+    - podman system prune -af
     # we can't use the default $CI_REGISTRY_USER/$CI_REGISTRY_PASSWORD because they're per-job
     # and these credentials need to be shared for the entire pipeline
     - podman login "$CI_REGISTRY" -u "$DEPLOYTOKEN_USER" --password-stdin <<<"$DEPLOYTOKEN_PASSWORD"


### PR DESCRIPTION
This ensures no stale cache is used, and that we have enough disk space for a full build