### PR TITLE
Remove Dockerfile version markers

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM archlinux/archlinux
 
 WORKDIR /tmp

--- a/languages/05ab1e/Dockerfile
+++ b/languages/05ab1e/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/elixir
 
 ARG OSABIE_REV=1d532f3aad3af265691c9c1bc601c246bfa2944e

--- a/languages/backhand/Dockerfile
+++ b/languages/backhand/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG BACKHAND_REV=8703a6d384005e18b0b87fd1360c241b9326ae07

--- a/languages/bash/Dockerfile
+++ b/languages/bash/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 # THE_ prefix because $BASH_VERSION is a special variable

--- a/languages/bc/Dockerfile
+++ b/languages/bc/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm bc

--- a/languages/bracmat/Dockerfile
+++ b/languages/bracmat/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/gcc
 
 ARG BRACMAT_REV=f151843735bf5cb60ef056c0023110329845d8f1

--- a/languages/brain-flak/Dockerfile
+++ b/languages/brain-flak/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/ruby
 
 ARG BRAINFLAK_REV=9665dec1bd07aadbfd5889ff742d5bec6d19d031

--- a/languages/cbqn/Dockerfile
+++ b/languages/cbqn/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/clang AS build
 
 ARG BQN_REV=76141f6fe642f87364be1c61894d60c5d22ca0bf

--- a/languages/chapel/Dockerfile
+++ b/languages/chapel/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG CHAPEL_VERSION=2.0.0

--- a/languages/charcoal/Dockerfile
+++ b/languages/charcoal/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG CHARCOAL_REV=796761f03b9d4861eb07c4a505c414d7fd747c30

--- a/languages/clang/Dockerfile
+++ b/languages/clang/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm clang llvm

--- a/languages/cognate/Dockerfile
+++ b/languages/cognate/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/clang
 
 ARG COGNATE_REV=7582199a03830dceb803c294686e09e3746cf814

--- a/languages/crystal/Dockerfile
+++ b/languages/crystal/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm crystal gmp libyaml

--- a/languages/csharp/Dockerfile
+++ b/languages/csharp/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG DOTNET_SDK_VERSION=6.0.100

--- a/languages/curry_kics2/Dockerfile
+++ b/languages/curry_kics2/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/curry_pakcs as build
 
 ARG KICS2_VERSION=3.0.0

--- a/languages/curry_pakcs/Dockerfile
+++ b/languages/curry_pakcs/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/swi_prolog
 
 ARG PAKCS_VERSION=3.5.1

--- a/languages/deno/Dockerfile
+++ b/languages/deno/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN export DENO_INSTALL=/usr/local && \

--- a/languages/dirac/Dockerfile
+++ b/languages/dirac/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/gcc
 
 ARG DIRAC_REV=c1a2b9c42f2dba5c685da0769093e08fc27878f2

--- a/languages/dzaima_apl/Dockerfile
+++ b/languages/dzaima_apl/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/java
 
 ARG APL_REV=5eb0a4205e27afa6122096a25008474eec562dc0

--- a/languages/elixir/Dockerfile
+++ b/languages/elixir/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/erlang
 
 RUN pacman -Syu elixir --noconfirm

--- a/languages/elm/Dockerfile
+++ b/languages/elm/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/node
 
 ARG ELM_VERSION=0.19.1

--- a/languages/erlang/Dockerfile
+++ b/languages/erlang/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 # https://rabbitmq-users.narkive.com/OtHXmuO6/rabbitmq-discuss-ll-alloc-errors-on-rabbitmq-2-1-1

--- a/languages/exceptionally/Dockerfile
+++ b/languages/exceptionally/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/whython
 
 ARG EXCEPTIONALLY_REV=cee69c6fa739d5f6606172f312fabb20ff73ad3d

--- a/languages/factor/Dockerfile
+++ b/languages/factor/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 # Nightly:

--- a/languages/flax/Dockerfile
+++ b/languages/flax/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG FLAX_REV=3823d7e7728977b8b65606fe7411d2bdf8024080

--- a/languages/funky2/Dockerfile
+++ b/languages/funky2/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/csharp AS build
 
 ARG FUNKY2_VERSION=v1.1

--- a/languages/gcc/Dockerfile
+++ b/languages/gcc/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm gcc-{objc,go,fortran,ada,d} boost

--- a/languages/go/Dockerfile
+++ b/languages/go/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm go

--- a/languages/haskell/Dockerfile
+++ b/languages/haskell/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN curl -L https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup -o ghcup && \

--- a/languages/haskell8/Dockerfile
+++ b/languages/haskell8/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN curl -L https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup -o ghcup && \

--- a/languages/hops/Dockerfile
+++ b/languages/hops/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/haskell
 
 ARG HOPS_REV=fa5c0c731d586a50b86d2b0c08350d53769295e9

--- a/languages/husk/Dockerfile
+++ b/languages/husk/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/haskell8
 
 ARG HUSK_REV=03b3cf96e93824075cc70cef4bb3fd7242bd2ad0

--- a/languages/j_but_longer/Dockerfile
+++ b/languages/j_but_longer/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG J_VERSION=903

--- a/languages/j_uby/Dockerfile
+++ b/languages/j_uby/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/ruby
 
 ARG J_UBY_REV=d95e2d0786ee639a7cf63f48a1404d657c56fbcd

--- a/languages/java/Dockerfile
+++ b/languages/java/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 # check not already installed

--- a/languages/jelly/Dockerfile
+++ b/languages/jelly/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG JELLY_REV=70c9fd93ab009c05dc396f8cc091f72b212fb188

--- a/languages/jq/Dockerfile
+++ b/languages/jq/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/pacman_python
 
 RUN pacman -Syu --noconfirm jq yq

--- a/languages/julia/Dockerfile
+++ b/languages/julia/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm julia

--- a/languages/kamilalisp/Dockerfile
+++ b/languages/kamilalisp/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/java
 
 ARG KAMILALISP_VER=0.3.0.1

--- a/languages/knight/Dockerfile
+++ b/languages/knight/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/node
 
 ARG KNIGHT_VERSION=3105797369241d3f36613b4da2778c24f93f94bd

--- a/languages/koka/Dockerfile
+++ b/languages/koka/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG KOKA_VERSION=2.4.2

--- a/languages/kotlin/Dockerfile
+++ b/languages/kotlin/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/java
 
 RUN pacman -Syu --noconfirm kotlin --assume-installed java-environment=17

--- a/languages/ktye_k/Dockerfile
+++ b/languages/ktye_k/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/gcc
 
 RUN curl -L https://github.com/ktye/i/releases/download/latest/k.c -o k.c && \

--- a/languages/labyrinth/Dockerfile
+++ b/languages/labyrinth/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/ruby
 
 ARG LABYRINTH_REV=d3cc04f398594549c1c85c8116ef146d461a5b6f

--- a/languages/lolcode/Dockerfile
+++ b/languages/lolcode/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG LOLCODE_VERSION=0.11.2

--- a/languages/lua/Dockerfile
+++ b/languages/lua/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm lua lua-filesystem

--- a/languages/neko/Dockerfile
+++ b/languages/neko/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm neko --assume-installed gtk3

--- a/languages/nekomata/Dockerfile
+++ b/languages/nekomata/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/haskell
 
 ARG NEKOMATA_VERSION=0.6.0.0

--- a/languages/ngn_apl/Dockerfile
+++ b/languages/ngn_apl/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/node
 
 ARG APL_REV=69fa5ba80f0ee846232e289934a9285da70a17ee

--- a/languages/ngn_k/Dockerfile
+++ b/languages/ngn_k/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/clang
 
 ARG K_REV=ba2c2bab7e533e8fdc4e4cc2ee0c0c939990d5f5

--- a/languages/nibbles/Dockerfile
+++ b/languages/nibbles/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/haskell8
 
 ARG NIBBLES_VERSION=1.01

--- a/languages/nim/Dockerfile
+++ b/languages/nim/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG NIM_VERSION=1.6.6

--- a/languages/node/Dockerfile
+++ b/languages/node/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG NODE_VERSION=v18.8.0

--- a/languages/ocaml/Dockerfile
+++ b/languages/ocaml/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm ocaml

--- a/languages/octave/Dockerfile
+++ b/languages/octave/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm octave

--- a/languages/ok/Dockerfile
+++ b/languages/ok/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/node
 
 ARG OK_REV=97956bf6f2ea795178cd19bd7ae80ebe3a4111de

--- a/languages/pacman_python/Dockerfile
+++ b/languages/pacman_python/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 # This is for languages which depend on python but where it's simplest to use pacman's version instead of custom-built
 
 FROM attemptthisonline/base

--- a/languages/pari_gp/Dockerfile
+++ b/languages/pari_gp/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 
 FROM attemptthisonline/base
 

--- a/languages/perl/Dockerfile
+++ b/languages/perl/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm perl

--- a/languages/php/Dockerfile
+++ b/languages/php/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm php

--- a/languages/pip/Dockerfile
+++ b/languages/pip/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG PIP_VERSION=v1.2.0

--- a/languages/powershell/Dockerfile
+++ b/languages/powershell/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG POWERSHELL_VERSION=7.3.4

--- a/languages/pyth/Dockerfile
+++ b/languages/pyth/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG PYTH_REV=bb7c848818caa96932a058ac047ef3b98f3527bf

--- a/languages/python/Dockerfile
+++ b/languages/python/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG PYTHON_VERSION=3.12.2

--- a/languages/python2/Dockerfile
+++ b/languages/python2/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG PYTHON_VERSION=2.7.18

--- a/languages/python310/Dockerfile
+++ b/languages/python310/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG PYTHON_VERSION=3.10.12

--- a/languages/python_with_common_libraries/Dockerfile
+++ b/languages/python_with_common_libraries/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 RUN pip install --no-cache-dir numpy sympy scipy Pillow chess regex

--- a/languages/quipu/Dockerfile
+++ b/languages/quipu/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/java
 
 ARG QUIPU_VERSION=0.1.0

--- a/languages/r_but_longer/Dockerfile
+++ b/languages/r_but_longer/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/perl
 
 RUN pacman -Syu --noconfirm r

--- a/languages/raku/Dockerfile
+++ b/languages/raku/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG RAKU_VERSION=2023.12-01

--- a/languages/regenerate/Dockerfile
+++ b/languages/regenerate/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG REGENERATE_REV=b130e9ae0d32d0f601ea126d9096013064e3186b

--- a/languages/retina/Dockerfile
+++ b/languages/retina/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/csharp AS build
 
 ARG RETINA_VERSION=v1.2.1

--- a/languages/rpaheui/Dockerfile
+++ b/languages/rpaheui/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN curl -fsSL https://raw.githubusercontent.com/Bubbler-4/rpaheui/66f153d454af2b2d21464b87fa67f953ab57f5ec/rpaheui -o /usr/local/bin/aheui && \

--- a/languages/ruby/Dockerfile
+++ b/languages/ruby/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG RUBY_VERSION=3.1.2

--- a/languages/rust/Dockerfile
+++ b/languages/rust/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm rustup && \

--- a/languages/sbcl/Dockerfile
+++ b/languages/sbcl/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG SBCL_VERSION=2.2.8

--- a/languages/scala2/Dockerfile
+++ b/languages/scala2/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/java
 
 ARG SCALA_VERSION=2.13.8

--- a/languages/scala3/Dockerfile
+++ b/languages/scala3/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/java
 
 ARG SCALA_VERSION=3.1.3

--- a/languages/slashes/Dockerfile
+++ b/languages/slashes/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/perl
 
 ARG SLASHES_REV=c3c84c8d98f5dbefe7d1b690c728dac3e5db1131

--- a/languages/swi_prolog/Dockerfile
+++ b/languages/swi_prolog/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm swi-prolog

--- a/languages/tcl/Dockerfile
+++ b/languages/tcl/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 RUN pacman -Syu --noconfirm tcl

--- a/languages/texlive/Dockerfile
+++ b/languages/texlive/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG TEXLIVE_VERSION=2024

--- a/languages/thunno/Dockerfile
+++ b/languages/thunno/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG THUNNO_REV=1.2.1

--- a/languages/thunno2/Dockerfile
+++ b/languages/thunno2/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 
 ARG THUNNO_REV=2.1.9

--- a/languages/tictac/Dockerfile
+++ b/languages/tictac/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python
 RUN curl -L https://github.com/pxeger/tictac/archive/main.tar.gz \
     | tar -xz \

--- a/languages/tio_brainfuck/Dockerfile
+++ b/languages/tio_brainfuck/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG BRAINFUCK_REV=9ef9a92460bae60188ce45a0ac64c8fb8d0898f8

--- a/languages/vyxal/Dockerfile
+++ b/languages/vyxal/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/python310
 
 ARG VYXAL_REV=v2.21.2

--- a/languages/whitespace/Dockerfile
+++ b/languages/whitespace/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/haskell
 
 ARG WSPACE_REV=5eb78c6afae9f5dd2d2012a1784f6483ec824135

--- a/languages/whython/Dockerfile
+++ b/languages/whython/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG WHYTHON_VERSION=3.10.0y2.1

--- a/languages/zig/Dockerfile
+++ b/languages/zig/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/clang
 
 RUN pacman -Syu --noconfirm zig

--- a/languages/zsh/Dockerfile
+++ b/languages/zsh/Dockerfile
@@ -1,4 +1,3 @@
-#syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM attemptthisonline/base
 
 ARG ZSH_VERSION=5.9


### PR DESCRIPTION
These were added because docker buildx bake could only do proper dependency analysis with the then-unreleased Dockerfile 1.4.0+ frontend; but (a) the Dockerfile frontend is way newer than that and (b) we no longer use docker buildx anyway