### PR TITLE
CI: use special job tag to ensure correct runner is used

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,7 @@ stages: [init, build]
 # template used for building docker images
 .base:
   stage: build
-  # TODO: add special tag to ensure the same runner is used for all jobs in this pipeline
-  tags: [Linux, shell_executor]
+  tags: [ato_buildbox]
 
 init:
   extends: .base


### PR DESCRIPTION
- By adding `ato_buildbox`, we ensure only the special buildbox runner will be used for these jobs
- Dually, by removing the generic tags `Linux` and `shell_executor`, we can remove those tags from the buildbox runner and thus ensure it doesn't get used to build anything else