### PR TITLE
Fix zsh ncurses incompatiblity

### DIFF
--- a/languages/zsh/Dockerfile
+++ b/languages/zsh/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -L https://www.zsh.org/pub/zsh-$ZSH_VERSION.tar.xz | tar -xJ && \
         --with-tcsetpgrp \
         --enable-pcre \
         && \
-    make && \
+    make CC="gcc -DHAVE_BOOLCODES" && \
     make install && \
     cd / && \
     rm -rf /tmp/zsh-$ZSH_VERSION


### PR DESCRIPTION
I'm not sure what actually caused this, but the problem was `./configure` not detecting `HAVE_BOOLCODES` correctly. so I overrode that.