### PR TITLE
Run CI on main branch only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,8 @@
 stages: [init, build]
 
-rules:
-  - if: $CI_COMMIT_BRANCH == "main"
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
 
 # template used for building docker images
 .base:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,8 @@
 stages: [init, build]
 
+rules:
+  - if: $CI_COMMIT_BRANCH == "main"
+
 # template used for building docker images
 .base:
   stage: build


### PR DESCRIPTION
the CI pushes to GitLab registry, which we don't want for PRs!
plus it duplicates the GitHub CI for pull requests

In the future I'll (maybe) consolidate the CI to only be on GitLab
