### PR TITLE
Update Picat to 3.6#8

### DIFF
--- a/languages/picat/Dockerfile
+++ b/languages/picat/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.gitlab.pxeger.com/attempt-this-online/languages/base
 
-ARG PICAT_VERSION=36
+ARG PICAT_VERSION=368
 
 RUN curl http://picat-lang.org/download/picat${PICAT_VERSION}_linux64.tar.gz | \
     tar -xz && \


### PR DESCRIPTION
Follows the link address on http://picat-lang.org/download.html