### PR TITLE
Update to today's Chapel 2.5 release

### DIFF
--- a/languages/chapel/Dockerfile
+++ b/languages/chapel/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.gitlab.pxeger.com/attempt-this-online/languages/base
 
-ARG CHAPEL_VERSION=2.4.0
+ARG CHAPEL_VERSION=2.5.0
 
 ENV CHPL_HOME=/opt/chapel CHPL_LLVM=none
 RUN pacman -Syu --noconfirm python cmake && \
@@ -8,6 +8,5 @@ RUN pacman -Syu --noconfirm python cmake && \
     tar -xz && \
     mv chapel-* /opt/chapel && \
     cd /opt/chapel && \
-    sed -i 's/3/4/g' third-party/llvm/cmake-ok.sh && \
     make -j $(nproc) && \
     ln -s $CHPL_HOME/bin/*/chpl /usr/local/bin/


### PR DESCRIPTION
This also removes the workaround we inserted last time for CMake 4 support.